### PR TITLE
Allow model paths outside the UIA-Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,21 +90,34 @@ This document provides a profound introduction into a Palladio extension which e
 		* Contact me!
 
 ### Step 4: Start Plugin in "inner" Eclipse Instance
-* Start new eclipse instance from current instance
-	* RightClick -> org.palladiosimulator.uncertainty.impact -> Run As -> Eclipse Application
-	* Create new workspace (do not reuse workspace of "outer" instance)
-	* Import org.palladiosimulator.uncertainty.impact from UncertaintPlugin
-		* Tree Editors for Uncertainty Models available in inner instance
-		* Sample uncertainty models located in
-			* src/test/resources
-			* src/main/resources
-		* Important: Do not change models in src/test/resources, as they are loaded for UnitTests
-			* Only create/change tests in src/main/resources
-	* Open Uncertainty View:
-		* Window -> Show View -> Other -> Search "UncertaintyView" -> Open
-		* Resize Window & Have fun!
+- Start new eclipse instance from current instance
+	- RightClick -> org.palladiosimulator.uncertainty.impact -> Run As -> Eclipse Application
+	- Create new workspace (do not reuse workspace of "outer" instance)
+    	- If not prompted to the _workspace selection dialog_,
+    	configur workspace in _Run Configurations_:
+			1. Create folder for "inner"-workspace next to the "outer"-workspace
+    		2. Open _Run Configurations_ dialog
+    		3. Under _Workspace Data_ insert
+    		`${workspace_loc}/../<foldername "inner"-workspace>`
+	- Import org.palladiosimulator.uncertainty.impact from UncertaintPlugin
+		- Tree Editors for Uncertainty Models available in inner instance
+		- Sample uncertainty models located in
+			- src/test/resources
+			- src/main/resources
+		- Important: Do not change models in src/test/resources, as they are loaded for UnitTests
+			- Only create/change tests in src/main/resources
+	- Open Uncertainty View:
+		- Window -> Show View -> Other -> Search "UncertaintyView" -> Open
+		- Resize Window & Have fun!
 
 ## Usage of UIA Plugin
+
+**Note:** The root directory for models to be analyzed is the "inner"-workspace folder.
+For example, for a project `org.palladiosimulator.uncertainty.impact`
+and models within this project `src/main/resources/models/...`
+the full path to be specified is
+`org.palladiosimulator.uncertainty.impact/src/main/resources/models/...`.
+For clarity, we let out the project name when specifying the paths in this documentation.
 
 ### Prerequisites
 * Installation completed
@@ -113,8 +126,10 @@ This document provides a profound introduction into a Palladio extension which e
 * Models loaded
 	* 1) Use sample models (already specified as default when starting the plugin)
 		* Palladio Models: Book Store Example
-		* Uncertainty Template Model: src/main/resources/models/expert/sample.uncertaintytemplate
-		* Uncertainty Model: src/main/resources/models/user/sample.uncertainty
+		* Uncertainty Template Model:
+			`src/main/resources/models/expert/sample.uncertaintytemplate`
+		* Uncertainty Model:
+			`src/main/resources/models/user/sample.uncertainty`
 	* 2) Define own models
 		* Models as specified in section *Models*
 		* Important: Models need to be in workspace (inner eclipse instance)!

--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ the full path to be specified is
 `org.palladiosimulator.uncertainty.impact/src/main/resources/models/...`.
 For clarity, we let out the project name when specifying the paths in this documentation.
 
+## Environment Variables
+This extension accepts the following environment variables:
+- `UIA_UNCERTAINTY_PATH`
+- `UIA_UNCERTAINTYTEMPLATE_PATH`
+- `UIA_ALLOCATION_MODEL_PATH`
+- `UIA_REPOSITORY_MODEL_PATH`
+- `UIA_RESOURCEENVIRONMENT_MODEL_PATH`
+- `UIA_SYSTEM_MODEL_PATH`
+- `UIA_USAGE_MODEL_PATH`
+
+If set, each variable will be used as the initial value for the _Uncertainty View_.
+
 ### Prerequisites
 * Installation completed
 * Plugin started

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/model/Model.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/model/Model.java
@@ -1,7 +1,5 @@
 package org.palladiosimulator.uncertainty.impact.model;
 
-import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,7 +59,7 @@ public abstract class Model {
 
 		for (final String modelPath : modelPaths) {
 			//Need to prepend plugin-relative prefix
-			Resource ressource = EMFPersistenceHelper.loadEmfResourceFromFile(PLUGIN_URI_PREFIX + modelPath, null, resourceSet);
+			Resource ressource = EMFPersistenceHelper.loadEmfResourceFromFile(modelPath, null, resourceSet);
 			listResources.add(ressource);
 		}
 

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/persistence/SaveUncertaintyModelHelper.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/persistence/SaveUncertaintyModelHelper.java
@@ -36,7 +36,7 @@ public class SaveUncertaintyModelHelper {
 			throw new SaveModelFailedException("Invalid path provided!");
 		}
 		
-		URI saveUri = getRelativePluginURI(modelPath);
+		URI saveUri = URI.createPlatformResourceURI(modelPath, false);
 
 		prepareUncertaintyModelForSaving(uncertaintyContainer);
 		EMFPersistenceHelper.saveEmfModelToURI(uncertaintyContainer, saveUri);
@@ -45,11 +45,6 @@ public class SaveUncertaintyModelHelper {
 
 	private static boolean checkPath(String modelPath) {
 		return modelPath.endsWith(FILEEXTENSION_UNCERTAINTY_WITH_DOT );
-	}
-
-	private static URI getRelativePluginURI(final String relativePath) {
-		// Need to use PlatformResourceURI for saving!
-		return URI.createPlatformResourceURI(PLUGIN_URI_PREFIX + relativePath, false);
 	}
 
 	/**

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/persistence/SaveUncertaintyPropagationModelHelper.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/persistence/SaveUncertaintyPropagationModelHelper.java
@@ -1,8 +1,5 @@
 package org.palladiosimulator.uncertainty.impact.persistence;
 
-import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
-import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.UNCERTAINTY_PROPAGATION_DEFAULT_LOCATION;
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -59,18 +56,13 @@ public class SaveUncertaintyPropagationModelHelper {
 	public static void saveUncertaintyPropagation(UCArchitectureVersion version, String path) throws SaveModelFailedException {
 
 		// Need to use PlatformResourceURI for saving!
-		URI uri = getRelativePluginURI(path);
+		URI uri = URI.createPlatformResourceURI(path, false);
 
 		// Delegate with default path
 		saveUncertaintyPropagation(version, uri);
 
 	}
-	
-	
-	private static URI getRelativePluginURI(final String relativePath) {
-		// Need to use PlatformResourceURI for saving!
-		return URI.createPlatformResourceURI(PLUGIN_URI_PREFIX + relativePath, false);
-	}
+
 
 	/**
 	 * In the course of the propagation, we create entities "on the fly" (i.e.

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/util/UncertaintyPluginConstants.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/util/UncertaintyPluginConstants.java
@@ -7,7 +7,7 @@ public class UncertaintyPluginConstants {
 	}
 
 	// Plugin related constants
-	public static final String PLUGIN_URI_PREFIX = "/org.palladiosimulator.uncertainty.impact/";
+	public static final String PLUGIN_URI_PREFIX = "org.palladiosimulator.uncertainty.impact/";
 
 	// Uncertainty propagation related constants
 	public static final String FILEEXTENSION_UNCERTAINTY_PROPAGATION = "uncertaintypropagation";

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadPalladioModelsView.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadPalladioModelsView.java
@@ -58,19 +58,39 @@ public class LoadPalladioModelsView extends AbstractView implements ILoadPalladi
 
 		// Create label and input fields for each palladio model
 		ViewFactory.createLabel(browseModelsComposite, "Path to repository file:");
+		String repositoryModelPath = System.getenv("UIA_REPOSITORY_MODEL_PATH"); 
+		if (repositoryModelPath != null) {
+			defaultRepositoryModelPath = repositoryModelPath;
+		}
 		pathToRepositoryField = ViewFactory.createText(browseModelsComposite, defaultRepositoryModelPath, 2);
 
 		ViewFactory.createLabel(browseModelsComposite, "Path to system file:");
+		String systemModelPath = System.getenv("UIA_SYSTEM_MODEL_PATH"); 
+		if (systemModelPath != null) {
+			defaultSystemModelPath = systemModelPath;
+		}
 		pathToSystemField = ViewFactory.createText(browseModelsComposite, defaultSystemModelPath, 2);
 
 		ViewFactory.createLabel(browseModelsComposite, "Path to allocation file:");
+		String allocationModelPath = System.getenv("UIA_ALLOCATION_MODEL_PATH"); 
+		if (allocationModelPath != null) {
+			defaultAllocationModelPath = allocationModelPath;
+		}
 		pathToAllocationField = ViewFactory.createText(browseModelsComposite, defaultAllocationModelPath, 2);
 
 		ViewFactory.createLabel(browseModelsComposite, "Path to resourceenvironment file:");
+		String resourceEnvironmentModelPath = System.getenv("UIA_RESOURCEENVIRONMENT_MODEL_PATH"); 
+		if (resourceEnvironmentModelPath != null) {
+			defaultResourceEnvironmentModelPath = resourceEnvironmentModelPath;
+		}
 		pathToResourceEnvironmentField = ViewFactory.createText(browseModelsComposite,
 				defaultResourceEnvironmentModelPath, 2);
 
 		ViewFactory.createLabel(browseModelsComposite, "Path to usagemodel file:");
+		String usageModelPath = System.getenv("UIA_USAGE_MODEL_PATH"); 
+		if (usageModelPath != null) {
+			defaultUsageModelPath = usageModelPath;
+		}
 		pathToUsageModelField = ViewFactory.createText(browseModelsComposite, defaultUsageModelPath, 2);
 
 	}

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadPalladioModelsView.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadPalladioModelsView.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.uncertainty.impact.view;
 
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,11 +33,16 @@ public class LoadPalladioModelsView extends AbstractView implements ILoadPalladi
 
 	private IPalladioViewListener listener;
 
-	private static String defaultAllocationModelPath = "src/main/resources/models/user/pcm/BookShop.allocation";
-	private static String defaultRepositoryModelPath = "src/main/resources/models/user/pcm/BookShop.repository";
-	private static String defaultResourceEnvironmentModelPath = "src/main/resources/models/user/pcm/BookShop.resourceenvironment";
-	private static String defaultSystemModelPath = "src/main/resources/models/user/pcm/BookShop.system";
-	private static String defaultUsageModelPath = "src/main/resources/models/user/pcm/BookShop.usagemodel";
+	private static String defaultAllocationModelPath =
+			PLUGIN_URI_PREFIX + "src/main/resources/models/user/pcm/BookShop.allocation";
+	private static String defaultRepositoryModelPath =
+			PLUGIN_URI_PREFIX + "src/main/resources/models/user/pcm/BookShop.repository";
+	private static String defaultResourceEnvironmentModelPath =
+			PLUGIN_URI_PREFIX + "src/main/resources/models/user/pcm/BookShop.resourceenvironment";
+	private static String defaultSystemModelPath =
+			PLUGIN_URI_PREFIX + "src/main/resources/models/user/pcm/BookShop.system";
+	private static String defaultUsageModelPath =
+			PLUGIN_URI_PREFIX + "src/main/resources/models/user/pcm/BookShop.usagemodel";
 
 	public LoadPalladioModelsView(Composite parent) {
 		super(parent);

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadUncertaintyTemplateModelView.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadUncertaintyTemplateModelView.java
@@ -42,6 +42,10 @@ public class LoadUncertaintyTemplateModelView extends AbstractView implements IL
 		
 		// Create label and input field
 		ViewFactory.createLabel(browseModelComposite, "Path to uncertainty template:        ");
+		String uncertaintyTemplatePath = System.getenv("UIA_UNCERTAINTYTEMPLATE_PATH");
+		if (uncertaintyTemplatePath != null) {
+			defaultUncertaintyTemplatePath = uncertaintyTemplatePath;
+		}
 		pathToUncertaintyTemplateField = ViewFactory.createText(browseModelComposite, defaultUncertaintyTemplatePath, 2);
 
 

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadUncertaintyTemplateModelView.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/LoadUncertaintyTemplateModelView.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.uncertainty.impact.view;
 
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -24,7 +26,8 @@ public class LoadUncertaintyTemplateModelView extends AbstractView implements IL
 
 	private Text pathToUncertaintyTemplateField;
 
-	private static String defaultUncertaintyTemplatePath = "src/main/resources/models/expert/sample.uncertaintytemplate";
+	private static String defaultUncertaintyTemplatePath =
+			PLUGIN_URI_PREFIX + "src/main/resources/models/expert/sample.uncertaintytemplate";
 
 	public LoadUncertaintyTemplateModelView(Composite parent) {
 		super(parent);

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/UncertaintyView.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/UncertaintyView.java
@@ -80,9 +80,13 @@ public class UncertaintyView extends AbstractView implements IUncertaintyView {
 		Composite loadUncertaintyModelComposite = ViewFactory.createComposite(parent, 4, 4);
 
 		ViewFactory.createLabel(loadUncertaintyModelComposite, "Path to uncertainty model");
-
+		
+		String uncertaintyPath = System.getenv("UIA_UNCERTAINTY_PATH");
+		if (uncertaintyPath == null) {
+			uncertaintyPath = PLUGIN_URI_PREFIX + "src/main/resources/models/user/sample.uncertainty";
+		}
 		uncertaintyModelPathText = ViewFactory.createText(loadUncertaintyModelComposite,
-				PLUGIN_URI_PREFIX + "src/main/resources/models/user/sample.uncertainty", 2);
+				uncertaintyPath, 2);
 
 		Button button = ViewFactory.createButton(loadUncertaintyModelComposite, "Load Model");
 		button.addListener(SWT.Selection, new Listener() {

--- a/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/UncertaintyView.java
+++ b/org.palladiosimulator.uncertainty.impact/src/main/java/org/palladiosimulator/uncertainty/impact/view/UncertaintyView.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.uncertainty.impact.view;
 
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,7 +82,7 @@ public class UncertaintyView extends AbstractView implements IUncertaintyView {
 		ViewFactory.createLabel(loadUncertaintyModelComposite, "Path to uncertainty model");
 
 		uncertaintyModelPathText = ViewFactory.createText(loadUncertaintyModelComposite,
-				"src/main/resources/models/user/sample.uncertainty", 2);
+				PLUGIN_URI_PREFIX + "src/main/resources/models/user/sample.uncertainty", 2);
 
 		Button button = ViewFactory.createButton(loadUncertaintyModelComposite, "Load Model");
 		button.addListener(SWT.Selection, new Listener() {

--- a/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertainty/impact/persistence/SaveUncertaintyModelHelperTest.java
+++ b/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertainty/impact/persistence/SaveUncertaintyModelHelperTest.java
@@ -47,7 +47,8 @@ public class SaveUncertaintyModelHelperTest extends TestBase {
 		model.addUncertainty(uncertainty_at_component_interface_instance);
 
 		// Execute save
-		SaveUncertaintyModelHelper.saveUncertaintyModel(model.getUncertaintyModel(), modelSavePath);
+		SaveUncertaintyModelHelper.saveUncertaintyModel(
+				model.getUncertaintyModel(), PLUGIN_URI_PREFIX + modelSavePath);
 
 		// Load saved model again (UncertaintyContainer is EMF representation for
 		// UncertaintyModel)

--- a/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/BookStoreLoader.java
+++ b/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/BookStoreLoader.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.uncertaintymodel.plugin;
 
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,11 +28,16 @@ import org.palladiosimulator.uncertainty.impact.uncertaintymodel.uncertainty.Com
  *
  */
 public class BookStoreLoader extends TestBase {// TODO adapt paths to required models
-	String allocationPath = "src/test/resources/models/user/pcm/BookShop.allocation";
-	String repositoryPath = "src/test/resources/models/user/pcm/BookShop.repository";
-	String resourceEnvPath = "src/test/resources/models/user/pcm/BookShop.resourceenvironment";
-	String systemPath = "src/test/resources/models/user/pcm/BookShop.system";
-	String usageModelPath = "src/test/resources/models/user/pcm/BookShop.usagemodel";
+	String allocationPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.allocation";
+	String repositoryPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.repository";
+	String resourceEnvPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.resourceenvironment";
+	String systemPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.system";
+	String usageModelPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.usagemodel";
 
 	List<String> palladioModelPaths = new ArrayList<>(
 			List.of(allocationPath, repositoryPath, resourceEnvPath, systemPath, usageModelPath));

--- a/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/TestBase.java
+++ b/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/TestBase.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.uncertaintymodel.plugin;
 
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -59,14 +61,21 @@ import tools.mdsd.library.standalone.initialization.StandaloneInitializationExce
 public abstract class TestBase {
 
 	// Paths to Palladio Test Models
-	public static final String allocationPath = "src/test/resources/models/user/pcm/BookShop.allocation";
-	public static final String repositoryPath = "src/test/resources/models/user/pcm/BookShop.repository";
-	public static final String resourceEnvPath = "src/test/resources/models/user/pcm/BookShop.resourceenvironment";
-	public static final String systemPath = "src/test/resources/models/user/pcm/BookShop.system";
-	public static final String usageModelPath = "src/test/resources/models/user/pcm/BookShop.usagemodel";
+	public static final String allocationPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.allocation";
+	public static final String repositoryPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.repository";
+	public static final String resourceEnvPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.resourceenvironment";
+	public static final String systemPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.system";
+	public static final String usageModelPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/pcm/BookShop.usagemodel";
 
-	public static final String uncertaintyPath = "src/test/resources/models/user/test.uncertainty";
-	public static final String uncertaintyTemplatePath = "src/test/resources/models/expert/test.uncertaintytemplate";
+	public static final String uncertaintyPath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/user/test.uncertainty";
+	public static final String uncertaintyTemplatePath =
+		PLUGIN_URI_PREFIX + "src/test/resources/models/expert/test.uncertaintytemplate";
 
 	public static final List<String> palladioModelPaths = new ArrayList<>(
 			List.of(allocationPath, repositoryPath, resourceEnvPath, systemPath, usageModelPath));

--- a/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/TestUncertaintyTemplateLoader.java
+++ b/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/TestUncertaintyTemplateLoader.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.uncertaintymodel.plugin;
 
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
+
 import org.palladiosimulator.evaluation.generator.PalladioModelConvenienceMethodGenerator;
 import org.palladiosimulator.uncertainty.impact.exception.LoadModelFailedException;
 import org.palladiosimulator.uncertainty.impact.exception.UncertaintyTemplateElementNotFoundException;
@@ -14,7 +16,8 @@ import org.palladiosimulator.uncertainty.impact.uncertaintymodel.uncertaintytype
  *
  */
 public class TestUncertaintyTemplateLoader extends TestBase {// TODO adapt paths to required models
-	private String uncertaintyTemplatePath = "src/test/resources/models/expert/test.uncertaintytemplate";
+	private String uncertaintyTemplatePath =
+			PLUGIN_URI_PREFIX + "src/test/resources/models/expert/test.uncertaintytemplate";
 
 	private UncertaintyTemplateModel model;
 

--- a/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/presenter/PalladioPresenterTest.java
+++ b/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/presenter/PalladioPresenterTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +76,7 @@ public class PalladioPresenterTest extends TestBase {
 		modelPaths.add(resourceEnvPath);
 		modelPaths.add(systemPath);
 		modelPaths.add(usageModelPath);
-		modelPaths.add("invalid.allocation");
+		modelPaths.add(PLUGIN_URI_PREFIX + "invalid.allocation");
 
 		cut.onLoadPalladioModelsButtonClicked(modelPaths);
 		assertFalse(palladioModel.isInitialized());

--- a/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/presenter/UncertaintyPresenterTest.java
+++ b/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/presenter/UncertaintyPresenterTest.java
@@ -369,7 +369,7 @@ public class UncertaintyPresenterTest extends TestBase {
 		uncertaintyTemplateModel.loadUncertaintyTemplateModel(uncertaintyTemplatePath);
 
 		// Execute test
-		cut.onLoadExistingModelButtonClicked("invalidPath");
+		cut.onLoadExistingModelButtonClicked(PLUGIN_URI_PREFIX + "invalidPath");
 
 		// Assert no model loaded
 		assertFalse(uncertaintyModel.isInitialized());
@@ -458,7 +458,7 @@ public class UncertaintyPresenterTest extends TestBase {
 		String modelSavePath = testDataPath + "temp.uncertainty";
 
 		// Execute test -> Save model to different location
-		cut.onSaveUncertaintyModelButtonClicked(modelSavePath);
+		cut.onSaveUncertaintyModelButtonClicked(PLUGIN_URI_PREFIX + modelSavePath);
 
 		// assert view is called correctly
 		verify(view).showMessage("Save uncertainty model successful!");

--- a/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/presenter/UncertaintyTemplatePresenterTest.java
+++ b/org.palladiosimulator.uncertainty.impact/src/test/java/org/palladiosimulator/uncertaintymodel/plugin/presenter/UncertaintyTemplatePresenterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.palladiosimulator.uncertainty.impact.util.UncertaintyPluginConstants.PLUGIN_URI_PREFIX;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ public class UncertaintyTemplatePresenterTest extends TestBase {
 
 	@Test
 	public void testOnLoadUncertaintyTemplateButtonClicked_NotSuccessfull() {
-		cut.onLoadUncertaintyTemplateButtonClicked("invalidPath");
+		cut.onLoadUncertaintyTemplateButtonClicked(PLUGIN_URI_PREFIX + "invalidPath");
 		assertFalse(uncertaintyTemplateModel.isInitialized());
 		verify(view, times(1)).showMessage("Error while loading uncertainty template model. Error message = "
 				+ "Load resource with path '/resource/org.palladiosimulator.uncertainty.impact/invalidPath' failed.");


### PR DESCRIPTION
Commit [6511461](https://github.com/FluidTrust/Palladio-Addons-Uncertainty-ImpactAnalysis/pull/3/commits/65114611e55908424249d93450af0fffd86b6a51):
Improve path specification for model loading.

Notes:
Constraint: module must exist in the "inner" eclipse workspace
Therefore,

- Do not prepend the `PLUGIN_URI_PREFIX` constant to custom paths
- Use `PLUGIN_URI_PREFIX` constant only for default (example) paths

Commit [8218b2f](https://github.com/FluidTrust/Palladio-Addons-Uncertainty-ImpactAnalysis/pull/3/commits/8218b2fb9374fbbf00949c926c62782a6f3867a0):
Additionally, this Palladio extension is now able to use environment variables to fill the initial model paths for the _Uncertainty View_.